### PR TITLE
Remove parent project reference

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="aa.truecaller">
-    <application
-        android:label="@string/app_name">
-    
-    </application>
 </manifest>


### PR DESCRIPTION
Removes reference to `app_name` string in parent project in library AndroidManifest