### PR TITLE
Handling Error Scenarios

### DIFF
--- a/android/src/main/java/aa/truecaller/TruecallerModule.java
+++ b/android/src/main/java/aa/truecaller/TruecallerModule.java
@@ -159,6 +159,7 @@ public class TruecallerModule extends ReactContextBaseJavaModule implements ITru
     public void onFailureProfileShared(@NonNull TrueError trueError) {
         WritableMap params = Arguments.createMap();
         params.putString("profile","error");
+        params.putInt("errorCode",trueError.getErrorType());
 
         sendEvent(reactContext, "profileErrorReponse", params);
 


### PR DESCRIPTION
The "onFailureProfileShared" callback method that you just implemented in the previous step helps you to handle all the possible failure cases when the user couldn't be verified successfully via the Truecaller flow.
Below are some of the possible failure scenarios and the corresponding error response that you receive for each of the cases :

Error Code      What it means
1                        Network Failure
2                       User pressed back
3                       Incorrect Partner Key
4 & 10              User Not Verified on Truecaller
5                       Truecaller App Internal Error
13                      User pressed back while verification in process
14                      User pressed "SKIP / USE ANOTHER NUMBER"

Link:  https://docs.truecaller.com/truecaller-sdk/android/integrating-with-your-app/handling-error-scenarios